### PR TITLE
fix column defaults not being generated when equals 0

### DIFF
--- a/omymodels/gino/core.py
+++ b/omymodels/gino/core.py
@@ -62,7 +62,7 @@ class ModelGenerator:
             column += gt.autoincrement
         if not column_data["nullable"]:
             column += gt.required
-        if column_data["default"]:
+        if column_data["default"] is not None:
             column = self.prepare_column_default(column_data, column)
         if column_data["name"] in table_pk:
             column += gt.pk_template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "omymodels"
-version = "0.4.2"
+version = "0.4.3"
 description = "O! My Models (omymodels) is a library to generate from SQL DDL Python Models for GinoORM."
 authors = ["Iuliia Volkova <xnuinside@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Hi, this is a quickfix for a situation when no default is generated for a DDL column with `default 0`.

For example for this input:
```
drop table if exists v2.entity ;
CREATE table v2.entity (
 description_id bigint not null default 0
 ,parent_entity_id bigint not null default 0
) ;
```
by applying `create_models`
The following output is produced:

```
from gino import Gino

db = Gino(schema="v2")


class Entity(db.Model):

    __tablename__ = 'entity'

    description_id = db.Column(db.BigInteger(), nullable=False)
    parent_entity_id = db.Column(db.BigInteger(), nullable=False)
```
