### PR TITLE
added Postgres current_timestamp function

### DIFF
--- a/omymodels/models/pydantic/core.py
+++ b/omymodels/models/pydantic/core.py
@@ -25,7 +25,7 @@ class ModelGenerator:
         if isinstance(column_type, tuple):
             _type = column_type[1]
         return _type
-    
+
     def get_not_custom_type(self, column: Column):
         _type = None
         if "." in column.type:
@@ -44,7 +44,7 @@ class ModelGenerator:
         if _type == "UUID":
             self.uuid_import = True
         return _type
-    
+
     def generate_attr(self, column: Dict, defaults_off: bool) -> str:
 
         _type = None
@@ -69,7 +69,7 @@ class ModelGenerator:
     @staticmethod
     def add_default_values(column_str: str, column: Dict) -> str:
         if column.type.upper() in datetime_types:
-            if "now" in column.default.lower():
+            if "now" in column.default.lower() or "current_timestamp" in column.default.lower():
                 # todo: need to add other popular PostgreSQL & MySQL functions
                 column.default = "datetime.datetime.now()"
             elif "'" not in column.default:

--- a/tests/integration/pydantic/test_pydantic.py
+++ b/tests/integration/pydantic/test_pydantic.py
@@ -13,6 +13,7 @@ def test_pydantic_models_are_working_as_expected(load_generated_code) -> None:
         ,status                varchar(10) not null
         ,event_time            timestamp not null default now()
         ,comment           varchar(1000) not null default 'none'
+        ,event_time2           timestamp not null default current_timestamp
         ) ;
 
 


### PR DESCRIPTION
Just added Postgres's current_timestamp function as a valid default setting of datetime fields, following the same behavior as if it was set "now()".