### PR TITLE
Fix Incorrect Column Type Crash

### DIFF
--- a/omymodels/models/dataclass/core.py
+++ b/omymodels/models/dataclass/core.py
@@ -52,9 +52,9 @@ class ModelGenerator:
         if column.default and defaults_off is False:
             column_str = self.add_column_default(column_str, column)
         if (
-                column.nullable
-                and not (column.default and not defaults_off)
-                and not defaults_off
+            column.nullable
+            and not (column.default and not defaults_off)
+            and not defaults_off
         ):
             column_str += dt.dataclass_default_attr.format(default=None)
         return column_str
@@ -71,13 +71,13 @@ class ModelGenerator:
         return column_str
 
     def generate_model(
-            self,
-            table: TableMeta,
-            singular: bool = True,
-            exceptions: Optional[List] = None,
-            defaults_off: Optional[bool] = False,
-            *args,
-            **kwargs,
+        self,
+        table: TableMeta,
+        singular: bool = True,
+        exceptions: Optional[List] = None,
+        defaults_off: Optional[bool] = False,
+        *args,
+        **kwargs,
     ) -> str:
         model = ""
 
@@ -85,11 +85,11 @@ class ModelGenerator:
         model += "\n\n"
         # generate class name
         model += (
-                     dt.dataclass_class.format(
-                         class_name=create_class_name(table.name, singular, exceptions),
-                         table_name=table.name,
-                     )
-                 ) + "\n\n"
+            dt.dataclass_class.format(
+                class_name=create_class_name(table.name, singular, exceptions),
+                table_name=table.name,
+            )
+        ) + "\n\n"
         columns = {"default": [], "non_default": []}
 
         # generate columns / attrs

--- a/omymodels/models/dataclass/core.py
+++ b/omymodels/models/dataclass/core.py
@@ -1,4 +1,7 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
+
+from table_meta import TableMeta
+from table_meta.model import Column
 
 import omymodels.types as t
 from omymodels.helpers import create_class_name, datetime_now_check
@@ -24,7 +27,7 @@ class ModelGenerator:
             column_type = column_type[0]
         return _type
 
-    def generate_attr(self, column: Dict, defaults_off: bool) -> str:
+    def generate_attr(self, column: Column, defaults_off: bool) -> str:
         column_str = dt.dataclass_attr
 
         if "." in column.type:
@@ -57,24 +60,22 @@ class ModelGenerator:
         return column_str
 
     @staticmethod
-    def add_column_default(column_str: str, column: Dict) -> str:
+    def add_column_default(column_str: str, column: Column) -> str:
         if column.type.upper() in datetime_types:
             if datetime_now_check(column.default.lower()):
                 # todo: need to add other popular PostgreSQL & MySQL functions
                 column.default = dt.field_datetime_now
             elif "'" not in column.default:
-                column.default = f"'{column['default']}'"
+                column.default = f"'{column.default}'"
         column_str += dt.dataclass_default_attr.format(default=column.default)
         return column_str
 
     def generate_model(
         self,
-        table: Dict,
+        table: TableMeta,
         singular: bool = True,
         exceptions: Optional[List] = None,
         defaults_off: Optional[bool] = False,
-        *args,
-        **kwargs,
     ) -> str:
         model = ""
 
@@ -103,7 +104,7 @@ class ModelGenerator:
             model += column
         return model
 
-    def create_header(self, *args, **kwargs) -> str:
+    def create_header(self) -> str:
         header = ""
         if self.uuid_import:
             header += dt.uuid_import + "\n"

--- a/omymodels/models/dataclass/core.py
+++ b/omymodels/models/dataclass/core.py
@@ -52,9 +52,9 @@ class ModelGenerator:
         if column.default and defaults_off is False:
             column_str = self.add_column_default(column_str, column)
         if (
-            column.nullable
-            and not (column.default and not defaults_off)
-            and not defaults_off
+                column.nullable
+                and not (column.default and not defaults_off)
+                and not defaults_off
         ):
             column_str += dt.dataclass_default_attr.format(default=None)
         return column_str
@@ -71,11 +71,13 @@ class ModelGenerator:
         return column_str
 
     def generate_model(
-        self,
-        table: TableMeta,
-        singular: bool = True,
-        exceptions: Optional[List] = None,
-        defaults_off: Optional[bool] = False,
+            self,
+            table: TableMeta,
+            singular: bool = True,
+            exceptions: Optional[List] = None,
+            defaults_off: Optional[bool] = False,
+            *args,
+            **kwargs,
     ) -> str:
         model = ""
 
@@ -83,11 +85,11 @@ class ModelGenerator:
         model += "\n\n"
         # generate class name
         model += (
-            dt.dataclass_class.format(
-                class_name=create_class_name(table.name, singular, exceptions),
-                table_name=table.name,
-            )
-        ) + "\n\n"
+                     dt.dataclass_class.format(
+                         class_name=create_class_name(table.name, singular, exceptions),
+                         table_name=table.name,
+                     )
+                 ) + "\n\n"
         columns = {"default": [], "non_default": []}
 
         # generate columns / attrs
@@ -104,7 +106,7 @@ class ModelGenerator:
             model += column
         return model
 
-    def create_header(self) -> str:
+    def create_header(self, *args, **kwargs) -> str:
         header = ""
         if self.uuid_import:
             header += dt.uuid_import + "\n"

--- a/omymodels/models/pydantic/core.py
+++ b/omymodels/models/pydantic/core.py
@@ -84,21 +84,23 @@ class ModelGenerator:
         return column_str
 
     def generate_model(
-        self,
-        table: TableMeta,
-        singular: bool = True,
-        exceptions: Optional[List] = None,
-        defaults_off: Optional[bool] = False,
+            self,
+            table: TableMeta,
+            singular: bool = True,
+            exceptions: Optional[List] = None,
+            defaults_off: Optional[bool] = False,
+            *args,
+            **kwargs,
     ) -> str:
         model = ""
         # mean one model one table
         model += "\n\n"
         model += (
-            pt.pydantic_class.format(
-                class_name=create_class_name(table.name, singular, exceptions),
-                table_name=table.name,
-            )
-        ) + "\n\n"
+                     pt.pydantic_class.format(
+                         class_name=create_class_name(table.name, singular, exceptions),
+                         table_name=table.name,
+                     )
+                 ) + "\n\n"
 
         for column in table.columns:
             column = t.prepare_column_data(column)
@@ -106,7 +108,7 @@ class ModelGenerator:
 
         return model
 
-    def create_header(self) -> str:
+    def create_header(self, *args, **kwargs) -> str:
         header = ""
         if self.uuid_import:
             header += pt.uuid_import + "\n"

--- a/omymodels/models/pydantic/core.py
+++ b/omymodels/models/pydantic/core.py
@@ -72,11 +72,11 @@ class ModelGenerator:
             if datetime_now_check(column.default.lower()):
                 # Handle functions like CURRENT_TIMESTAMP
                 column.default = "datetime.datetime.now()"
-            elif column.default.upper() != 'NULL' and "'" not in column.default:
+            elif column.default.upper() != "NULL" and "'" not in column.default:
                 column.default = f"'{column.default}'"
 
         # If the default is 'NULL', don't set a default in Pydantic (it already defaults to None)
-        if column.default.upper() == 'NULL':
+        if column.default.upper() == "NULL":
             return column_str
 
         # Append the default value if it's not None (e.g., explicit default values like '0' or CURRENT_TIMESTAMP)
@@ -84,23 +84,23 @@ class ModelGenerator:
         return column_str
 
     def generate_model(
-            self,
-            table: TableMeta,
-            singular: bool = True,
-            exceptions: Optional[List] = None,
-            defaults_off: Optional[bool] = False,
-            *args,
-            **kwargs,
+        self,
+        table: TableMeta,
+        singular: bool = True,
+        exceptions: Optional[List] = None,
+        defaults_off: Optional[bool] = False,
+        *args,
+        **kwargs,
     ) -> str:
         model = ""
         # mean one model one table
         model += "\n\n"
         model += (
-                     pt.pydantic_class.format(
-                         class_name=create_class_name(table.name, singular, exceptions),
-                         table_name=table.name,
-                     )
-                 ) + "\n\n"
+            pt.pydantic_class.format(
+                class_name=create_class_name(table.name, singular, exceptions),
+                table_name=table.name,
+            )
+        ) + "\n\n"
 
         for column in table.columns:
             column = t.prepare_column_data(column)

--- a/omymodels/types.py
+++ b/omymodels/types.py
@@ -116,7 +116,7 @@ def process_types_after_models_parser(column_data: Column) -> Column:
     return column_data
 
 
-def prepare_column_data(column_data: Column) -> str:
+def prepare_column_data(column_data: Column) -> Column:
     if "." in column_data.type or "(":
         column_data = process_types_after_models_parser(column_data)
     return column_data


### PR DESCRIPTION
The column type was referencing a Dict when it was actually a Column class.

@xnuinside , if you install the Pydantic plugin, it will highlight all the type mismatches.