### PR TITLE
Complete Type Mapping

### DIFF
--- a/omymodels/logic.py
+++ b/omymodels/logic.py
@@ -1,10 +1,12 @@
 from typing import Dict, List
 
+from table_meta.model import Column
+
 import omymodels.types as t
 
 
 def generate_column(
-    column_data: Dict,
+    column_data: Column,
     table_pk: List[str],
     table_data: Dict,
     schema_global: bool,
@@ -24,7 +26,7 @@ def generate_column(
 
 
 def setup_column_attributes(
-    column_data: Dict,
+    column_data: Column,
     table_pk: List[str],
     column: str,
     table_data: Dict,

--- a/omymodels/models/pydantic/core.py
+++ b/omymodels/models/pydantic/core.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
 
-from table_meta.model import Column
+from table_meta.model import Column, TableMeta
 
 import omymodels.types as t
 from omymodels.helpers import create_class_name, datetime_now_check
@@ -11,7 +11,7 @@ from omymodels.types import datetime_types
 
 class ModelGenerator:
     def __init__(self):
-        self.imports = set([pt.base_model])
+        self.imports = {pt.base_model}
         self.types_for_import = ["Json"]
         self.datetime_import = False
         self.typing_imports = set()
@@ -19,21 +19,20 @@ class ModelGenerator:
         self.uuid_import = False
         self.prefix = ""
 
-    def add_custom_type(self, target_type):
+    def add_custom_type(self, target_type: str) -> Optional[str]:
         column_type = self.custom_types.get(target_type, None)
         _type = None
         if isinstance(column_type, tuple):
             _type = column_type[1]
         return _type
 
-    def get_not_custom_type(self, column: Column):
+    def get_not_custom_type(self, column: Column) -> str:
         _type = None
         if "." in column.type:
             _type = column.type.split(".")[1]
         else:
             _type = column.type.lower().split("[")[0]
-        if _type == _type:
-            _type = types_mapping.get(_type, _type)
+        _type = types_mapping.get(_type, _type)
         if _type in self.types_for_import:
             self.imports.add(_type)
         elif "datetime" in _type:
@@ -43,9 +42,13 @@ class ModelGenerator:
             _type = f"List[{_type}]"
         if _type == "UUID":
             self.uuid_import = True
+        if "List" in _type:
+            self.typing_imports.add("List")
+        if "Any" == _type:
+            self.typing_imports.add("Any")
         return _type
 
-    def generate_attr(self, column: Dict, defaults_off: bool) -> str:
+    def generate_attr(self, column: Column, defaults_off: bool) -> str:
         _type = None
 
         if column.nullable:
@@ -53,6 +56,7 @@ class ModelGenerator:
             column_str = pt.pydantic_optional_attr
         else:
             column_str = pt.pydantic_attr
+
         if self.custom_types:
             _type = self.add_custom_type(column.type)
         if not _type:
@@ -60,40 +64,47 @@ class ModelGenerator:
 
         column_str = column_str.format(arg_name=column.name, type=_type)
 
-        if column.default and defaults_off is False:
+        if column.default is not None and not defaults_off:
             column_str = self.add_default_values(column_str, column)
 
         return column_str
 
     @staticmethod
-    def add_default_values(column_str: str, column: Dict) -> str:
+    def add_default_values(column_str: str, column: Column) -> str:
+        # Handle datetime default values
         if column.type.upper() in datetime_types:
             if datetime_now_check(column.default.lower()):
-                # todo: need to add other popular PostgreSQL & MySQL functions
+                # Handle functions like CURRENT_TIMESTAMP
                 column.default = "datetime.datetime.now()"
-            elif "'" not in column.default:
-                column.default = f"'{column['default']}'"
+            elif column.default.upper() != 'NULL' and "'" not in column.default:
+                column.default = f"'{column.default}'"
+
+        # If the default is 'NULL', don't set a default in Pydantic (it already defaults to None)
+        if column.default.upper() == 'NULL':
+            return column_str
+
+        # Append the default value if it's not None (e.g., explicit default values like '0' or CURRENT_TIMESTAMP)
         column_str += pt.pydantic_default_attr.format(default=column.default)
         return column_str
 
     def generate_model(
-        self,
-        table: Dict,
-        singular: bool = True,
-        exceptions: Optional[List] = None,
-        defaults_off: Optional[bool] = False,
-        *args,
-        **kwargs,
+            self,
+            table: TableMeta,
+            singular: bool = True,
+            exceptions: Optional[List] = None,
+            defaults_off: Optional[bool] = False,
+            *args,
+            **kwargs,
     ) -> str:
         model = ""
         # mean one model one table
         model += "\n\n"
         model += (
-            pt.pydantic_class.format(
-                class_name=create_class_name(table.name, singular, exceptions),
-                table_name=table.name,
-            )
-        ) + "\n\n"
+                     pt.pydantic_class.format(
+                         class_name=create_class_name(table.name, singular, exceptions),
+                         table_name=table.name,
+                     )
+                 ) + "\n"
 
         for column in table.columns:
             column = t.prepare_column_data(column)

--- a/omymodels/models/pydantic/templates.py
+++ b/omymodels/models/pydantic/templates.py
@@ -1,4 +1,4 @@
-datetime_import = """import datetime"""
+datetime_import = """import datetime as datetime"""
 typing_imports = """from typing import {typing_types}"""
 uuid_import = """from uuid import UUID"""
 

--- a/omymodels/models/pydantic/types.py
+++ b/omymodels/models/pydantic/types.py
@@ -1,39 +1,6 @@
 from omymodels.types import (
-    big_integer_types,
-    binary_types,
-    boolean_types,
-    datetime_types,
-    float_types,
-    integer_types,
-    json_types,
-    numeric_types,
     populate_types_mapping,
-    string_types,
-    text_types,
+    mapper,
 )
 
-mapper = {
-    string_types: "str",
-    integer_types: "int",
-    big_integer_types: "int",
-    float_types: "float",
-    numeric_types: "float",
-    boolean_types: "bool",
-    datetime_types: "datetime.datetime",
-    json_types: "Json",
-    text_types: "str",
-    binary_types: "bytes",
-}
-
 types_mapping = populate_types_mapping(mapper)
-
-direct_types = {
-    "date": "datetime.date",
-    "timestamp": "datetime.datetime",
-    "smallint": "int",
-    "jsonb": "Json",
-    "uuid": "UUID",
-}
-
-
-types_mapping.update(direct_types)

--- a/omymodels/types.py
+++ b/omymodels/types.py
@@ -109,8 +109,10 @@ mapper = {
     binary_types: "bytes",
     json_types: "Any",
     uuid_types: "str",  # Map to 'str' to be compatible with Pydantic and then validated as UUID
+    ("point",): "List[float]",  # Representing point as [float, float]
+    ("linestring",): "List[List[float]]",  # List of points
+    ("polygon",): "List[List[List[float]]]",  # List of LineStrings
 }
-
 
 def populate_types_mapping(mapper_dict: Dict[tuple, str]) -> Dict[str, str]:
     """

--- a/omymodels/types.py
+++ b/omymodels/types.py
@@ -1,81 +1,164 @@
-from typing import Dict
+from typing import Dict, Any
 
 from table_meta.model import Column
 
-postgresql_dialect = ["ARRAY", "JSON", "JSONB", "UUID"]
+# Define PostgreSQL-specific dialect types
+postgresql_dialect = ["ARRAY", "JSON", "JSONB", "UUID", "TIMESTAMPTZ", "INTERVAL", "BYTEA", "SERIAL", "BIGSERIAL"]
+
+# Define MySQL-specific dialect types
+mysql_dialect = ["ENUM", "SET", "JSON"]
 
 string_types = (
-    "str",
-    "varchar",
-    "character",
-    "character varying",
-    "varying",
     "char",
+    "character",
+    "varchar",
+    "character varying",
+    "varying character",
     "string",
-    "String",
+    "str",
 )
 
-text_types = ("text", "Text")
-datetime_types = (
-    "DATETIME",
-    "time",
-    "datetime.datetime",
-    "datetime",
-    "datetime.date",
-    "date",
+text_types = (
+    "text",
+    "tinytext",
+    "mediumtext",
+    "longtext",
 )
 
 binary_types = (
-    "BINARY",
-    "VARBINARY",
     "binary",
     "varbinary",
+    "blob",
+    "tinyblob",
+    "mediumblob",
+    "longblob",
 )
 
-json_types = ("union[dict, list]", "json", "union")
+integer_types = (
+    "tinyint",
+    "smallint",
+    "mediumint",
+    "int",
+    "integer",
+)
 
-integer_types = ("integer", "int", "serial")
+big_integer_types = ("bigint",)
 
-big_integer_types = ("bigint", "bigserial")
+float_types = (
+    "float",
+    "double",
+    "real",
+)
 
-float_types = ("float",)
+numeric_types = (
+    "decimal",
+    "numeric",
+)
 
-numeric_types = ("decimal", "numeric", "double")
-
-boolean_types = ("boolean", "bool")
+boolean_types = (
+    "boolean",
+    "bool",
+    "bit",
+)
 
 datetime_types = (
-    "TIMESTAMP",
-    "DATETIME",
-    "DATE",
-    "datetime.datetime",
-    "datetime",
-    "datetime.date",
     "date",
+    "datetime",
+    "timestamp",
+    "time",
+    "year",
 )
 
+json_types = (
+    "json",
+)
 
-def populate_types_mapping(mapper: Dict) -> Dict:
+uuid_types = (
+    "uuid",
+)
+
+# PostgreSQL-Specific Types
+postgresql_specific_mapper = {
+    "array": "List[Any]",       # PostgreSQL arrays can be mapped to Python lists
+    "json": "Any",
+    "jsonb": "Any",
+    "timestamptz": "datetime",  # For PostgreSQL's timezone-aware timestamp
+    "interval": "float",        # Intervals can be represented as floating-point seconds
+    "bytea": "bytes",           # PostgreSQL binary data
+    "serial": "int",            # PostgreSQL auto-incrementing serial type
+    "bigserial": "float",         # PostgreSQL auto-incrementing bigserial type
+}
+
+# MySQL-Specific Types
+mysql_specific_mapper = {
+    "enum": "str",         # Alternatively, map to specific Enum classes
+    "set": "List[str]",
+    "json": "Any",
+}
+
+# General mapper for both MySQL and PostgreSQL
+mapper = {
+    string_types: "str",
+    text_types: "str",
+    integer_types: "int",
+    big_integer_types: "float",
+    float_types: "float",
+    numeric_types: "float",
+    boolean_types: "bool",
+    datetime_types: "datetime",
+    binary_types: "bytes",
+    json_types: "Any",
+    uuid_types: "str",  # Map to 'str' to be compatible with Pydantic and then validated as UUID
+}
+
+
+def populate_types_mapping(mapper_dict: Dict[tuple, str]) -> Dict[str, str]:
+    """
+    Populates a dictionary mapping each type to its corresponding Pydantic type.
+    All type keys are converted to lowercase for case-insensitive matching.
+    """
     types_mapping = {}
-    for type_group, value in mapper.items():
+    for type_group, pydantic_type in mapper_dict.items():
         for type_ in type_group:
-            types_mapping[type_] = value
+            types_mapping[type_.lower()] = pydantic_type
     return types_mapping
 
 
-def prepare_type(column_data: Dict, models_types_mapping: Dict) -> str:
-    column_type = None
+# Generate the general types_mapping using the mapper
+types_mapping = populate_types_mapping(mapper)
+
+
+def prepare_type(column_data: Column, models_types_mapping: Dict[str, str]) -> str:
+    """
+    Determines the Pydantic type for a given column, handling special cases.
+    Specifically maps 'tinyint(1)' to 'bool' in MySQL.
+    """
     column_data_type = column_data.type.lower().split("[")[0]
-    if not column_type:
-        column_type = models_types_mapping.get(column_data_type, column_type)
+
+    # Special handling for MySQL tinyint(1) -> bool
+    if column_data_type.startswith("tinyint"):
+        size = column_data.size
+        if size == 1:
+            return "bool"
+        else:
+            column_data_type = "tinyint"
+
+    # Get the Pydantic type from the mapping
+    column_type = models_types_mapping.get(column_data_type)
+
+    # Default to the column data type if not found in mapping
     if not column_type:
         column_type = column_data_type
+
     return column_type
 
 
 def add_custom_type_orm(
-    custom_types: Dict, column_data_type: str, column_type: str
+    custom_types: Dict[str, Any], column_data_type: str, column_type: str
 ) -> str:
+    """
+    Adds custom type mappings from the ORM's custom_types dictionary.
+    """
     if "." in column_data_type:
         column_data_type = column_data_type.split(".")[1]
     column_type = custom_types.get(column_data_type, column_type)
@@ -88,15 +171,22 @@ def add_custom_type_orm(
     return column_type
 
 
-def set_column_size(column_type: str, column_data: Dict) -> str:
-    if isinstance(column_data.size, int):
-        column_type += f"({column_data.size})"
-    elif isinstance(column_data.size, tuple):
-        column_type += f"({','.join([str(x) for x in column_data.size])})"
+def set_column_size(column_type: str, column_data: Column) -> str:
+    """
+    Appends the size or precision/scale to the column type if applicable.
+    """
+    size = column_data.size
+    if isinstance(size, int):
+        column_type += f"({size})"
+    elif isinstance(size, tuple):
+        column_type += f"({','.join([str(x) for x in size])})"
     return column_type
 
 
-def add_size_to_orm_column(column_type: str, column_data: Dict) -> str:
+def add_size_to_orm_column(column_type: str, column_data: Column) -> str:
+    """
+    Adds size information to the column type if available.
+    """
     if column_data.size:
         column_type = set_column_size(column_type, column_data)
     elif column_type != "UUID" and "(" not in column_type:
@@ -105,37 +195,73 @@ def add_size_to_orm_column(column_type: str, column_data: Dict) -> str:
 
 
 def process_types_after_models_parser(column_data: Column) -> Column:
-    if "." in column_data.type:
-        column_data.type = column_data.type.split(".")[1]
-    if "(" in column_data.type:
-        if "Enum" not in column_data.type:
-            column_data.type = column_data.type.split("(")[0]
+    """
+    Processes the column type string to remove schema qualifiers and parameters.
+    """
+    type_str = column_data.type
+    if "." in type_str:
+        type_str = type_str.split(".")[1]
+    if "(" in type_str:
+        if "Enum" not in type_str:
+            type_str = type_str.split("(")[0]
         else:
-            column_data.type = column_data.type.split("Enum(")[1].replace(")", "")
-    column_data.type = column_data.type.lower()
+            type_str = type_str.split("Enum(")[1].replace(")", "")
+    column_data.type = type_str.lower()
     return column_data
 
 
-def prepare_column_data(column_data: Column) -> str:
-    if "." in column_data.type or "(":
+def prepare_column_data(column_data: Column) -> Column:
+    """
+    Prepares the column data by processing the type string.
+    """
+    if "." in column_data.type or "(" in column_data.type:
         column_data = process_types_after_models_parser(column_data)
     return column_data
 
 
-def prepare_column_type_orm(obj: object, column_data: Column) -> str:
+def prepare_column_type_orm(obj: Any, column_data: Column) -> str:
+    """
+    Prepares the Pydantic type for a given column based on the ORM object and column data.
+    Handles both MySQL and PostgreSQL dialects, including custom types and size specifications.
+    """
     column_type = None
     column_data = prepare_column_data(column_data)
-    if obj.custom_types:
+
+    # Determine dialect based on obj; assuming obj has a 'dialect' attribute
+    dialect = getattr(obj, 'dialect', 'mysql').lower()  # default to MySQL if not specified
+
+    # Handle custom types if any
+    if hasattr(obj, 'custom_types') and obj.custom_types:
         column_type = add_custom_type_orm(
             obj.custom_types, column_data.type, column_type
         )
-    if not column_type:
-        column_type = prepare_type(column_data, obj.types_mapping)
-    if column_type in postgresql_dialect:
-        obj.postgresql_dialect_cols.add(column_type)
 
+    # Prepare general type
+    if not column_type:
+        column_type = prepare_type(column_data, types_mapping)
+
+    # Apply dialect-specific mappings
+    if dialect == "postgresql":
+        if column_type.upper() in postgresql_dialect:
+            obj.postgresql_dialect_cols.add(column_type.upper())
+        # Apply PostgreSQL-specific mappings
+        column_type = postgresql_specific_mapper.get(column_type.lower(), column_type)
+    elif dialect == "mysql":
+        if column_type.upper() in mysql_dialect:
+            obj.mysql_dialect_cols.add(column_type.upper())
+        # Apply MySQL-specific mappings
+        column_type = mysql_specific_mapper.get(column_type.lower(), column_type)
+
+    # Add size if applicable
     column_type = add_size_to_orm_column(column_type, column_data)
-    if "[" in column_data.type and column_data.type not in json_types:
+
+    # Handle array types
+    if "[" in column_data.type and dialect == "postgresql" and column_data.type not in json_types:
         obj.postgresql_dialect_cols.add("ARRAY")
-        column_type = f"ARRAY({column_type})"
+        column_type = f"List[{column_type}]"
+    elif "[" in column_data.type and dialect == "mysql" and column_data.type not in json_types:
+        # MySQL doesn't support native arrays, consider using List or JSON
+        obj.mysql_dialect_cols.add("ARRAY")
+        column_type = f"List[{column_type}]"
+
     return column_type


### PR DESCRIPTION
I've added the complete types for MySQL and PostgreSQL. Correct pydantic types are now generated.

```python
import datetime as datetime
from typing import Any, List, Optional
from pydantic import BaseModel


class TestTable(BaseModel):
    id: int
    tiny_int_example: Optional[int]
    small_int_example: Optional[int] = 0
    medium_int_example: Optional[int] = 0
    big_int_example: Optional[float] = 0
    decimal_example: Optional[float] = 0.00
    float_example: Optional[float] = 0
    double_example: Optional[float] = 0
    time_example: Optional[datetime]
    start_date: Optional[datetime]
    end_date: Optional[datetime]
    year_example: Optional[datetime]
    char_example: Optional[str]
    varchar_example: Optional[str]
    tiny_text_example: Optional[str]
    text_example: Optional[str]
    medium_text_example: Optional[str]
    long_text_example: Optional[str]
    binary_example: Optional[bytes]
    varbinary_example: Optional[bytes]
    tiny_blob_example: Optional[bytes]
    blob_example: Optional[bytes]
    medium_blob_example: Optional[bytes]
    long_blob_example: Optional[bytes]
    json_example: Optional[Any]
    boolean_example: Optional[int] = 0
    point_example: Optional[List[float]]
    line_example: Optional[List[List[float]]]
    polygon_example: Optional[List[List[List[float]]]]
```