### PR TITLE
Booleans are now capitalized

### DIFF
--- a/omymodels/from_ddl.py
+++ b/omymodels/from_ddl.py
@@ -172,7 +172,15 @@ def prepare_data(item: Dict) -> Dict:
                 item[key] = clean_value(value)
             elif isinstance(value, dict):
                 value = prepare_data(value)
+        else:
+            item[key] = format_to_py_var(value)
     return item
+
+
+def format_to_py_var(value: str) -> str:
+    if value in ["false", "true"]:
+        return value.capitalize()
+    return value
 
 
 def clean_value(string: str) -> str:

--- a/tests/functional/generator/test_dataclasses.py
+++ b/tests/functional/generator/test_dataclasses.py
@@ -203,3 +203,30 @@ CREATE TABLE "material" (
 """
     result = create_models(ddl, models_type="dataclass")["code"]
     assert expected == result
+
+
+def test_default_boolean():
+    expected = """from dataclasses import dataclass
+
+
+@dataclass
+class Material:
+
+    id: int
+    name: str
+    edited: bool = False
+    deleted: bool = True
+"""
+
+    ddl = """
+    CREATE TABLE Material
+    (
+        id integer,
+        name      string,
+        edited   boolean DEFAULT false,
+        deleted  boolean DEFAULT true,
+        PRIMARY KEY (id, name)
+    );
+    """
+    result = create_models(ddl, models_type="dataclass")["code"]
+    assert expected == result


### PR DESCRIPTION
Check if default variables are booleans. If so, capitalise them.
- Add test case for this scenario

resolves #65