### PR TITLE
Fix enums including whitespace

### DIFF
--- a/omymodels/models/enum/template.jinja2
+++ b/omymodels/models/enum/template.jinja2
@@ -1,6 +1,10 @@
 {% for _type in custom_types %}
-
-class {{_type['name']}}({{_type['parents']}}):
-
-    {% for key, value in _type['properties']['values'].items() %}{{key}} = {{value}}
-    {% endfor %}{% endfor %}
+{{ _type['name'] }} = Enum(
+    value='{{ _type['name'] }}',
+    names=[
+        {%- for key, value in _type['properties']['values'].items() %}
+        ('{{ key }}', {{ value }}){% if not loop.last %},{% endif %}
+        {%- endfor %}
+    ]
+)
+{% endfor %}

--- a/tests/functional/converter/test_converter.py
+++ b/tests/functional/converter/test_converter.py
@@ -34,12 +34,14 @@ from sqlalchemy.dialects.postgresql import JSON
 
 db = Gino()
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', article),
+        ('video', video)
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = article
-    video = video
-    
 
 class Material(db.Model):
 
@@ -100,12 +102,14 @@ from sqlalchemy.dialects.postgresql import JSON
 
 db = Gino()
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(db.Model):
 
@@ -161,12 +165,14 @@ import datetime
 from typing import Optional
 from pydantic import BaseModel, Json
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(BaseModel):
 

--- a/tests/functional/generator/test_dataclasses.py
+++ b/tests/functional/generator/test_dataclasses.py
@@ -73,12 +73,14 @@ import datetime
 from typing import Union
 from dataclasses import dataclass, field
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 @dataclass
 class Material:
@@ -119,12 +121,14 @@ import datetime
 from typing import Union
 from dataclasses import dataclass, field
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 @dataclass
 class Material:
@@ -165,12 +169,14 @@ import datetime
 from typing import Union
 from dataclasses import dataclass, field
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 @dataclass
 class Material:

--- a/tests/functional/generator/test_enum_only.py
+++ b/tests/functional/generator/test_enum_only.py
@@ -12,12 +12,14 @@ def test_enum_only():
 
     expected = """from enum import Enum
 
-
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    """
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
+"""
 
     assert result == expected
 
@@ -33,18 +35,22 @@ def test_enum_models():
     result = create_models(ddl)["code"]
     expected = """from enum import Enum, IntEnum
 
+ContentType = Enum(
+    value='ContentType',
+    names=[
+        ('HTML', 'HTML'),
+        ('MARKDOWN', 'MARKDOWN'),
+        ('TEXT', 'TEXT')
+    ]
+)
 
-class ContentType(str, Enum):
-
-    HTML = 'HTML'
-    MARKDOWN = 'MARKDOWN'
-    TEXT = 'TEXT'
-    
-
-class Period(IntEnum):
-
-    zero = 0
-    one = 1
-    two = 2
-    """
+Period = Enum(
+    value='Period',
+    names=[
+        ('zero', 0),
+        ('one', 1),
+        ('two', 2)
+    ]
+)
+"""
     assert expected == result

--- a/tests/functional/generator/test_enum_only.py
+++ b/tests/functional/generator/test_enum_only.py
@@ -54,3 +54,23 @@ Period = Enum(
 )
 """
     assert expected == result
+
+def test_enum_with_whitespace():
+    ddl = """
+    CREATE TYPE "enum_with_spaces" AS ENUM (
+    'some value',
+    'another value'
+    );
+    """
+    result = create_models(ddl)["code"]
+    expected = """from enum import Enum
+
+EnumWithSpaces = Enum(
+    value='EnumWithSpaces',
+    names=[
+        ('another value', 'another value'),
+        ('some value', 'some value')
+    ]
+)
+"""
+    assert result == expected

--- a/tests/functional/generator/test_enums.py
+++ b/tests/functional/generator/test_enums.py
@@ -7,13 +7,15 @@ from enum import Enum
 
 db = Gino(schema="schema--notification")
 
+ContentType = Enum(
+    value='ContentType',
+    names=[
+        ('HTML', 'HTML'),
+        ('MARKDOWN', 'MARKDOWN'),
+        ('TEXT', 'TEXT')
+    ]
+)
 
-class ContentType(str, Enum):
-
-    HTML = 'HTML'
-    MARKDOWN = 'MARKDOWN'
-    TEXT = 'TEXT'
-    
 
 class Notification(db.Model):
 
@@ -51,20 +53,24 @@ def test_pydantic_models():
 from typing import Optional
 from pydantic import BaseModel
 
+ContentType = Enum(
+    value='ContentType',
+    names=[
+        ('HTML', 'HTML'),
+        ('MARKDOWN', 'MARKDOWN'),
+        ('TEXT', 'TEXT')
+    ]
+)
 
-class ContentType(str, Enum):
+Period = Enum(
+    value='Period',
+    names=[
+        ('zero', 0),
+        ('one', 1),
+        ('two', 2)
+    ]
+)
 
-    HTML = 'HTML'
-    MARKDOWN = 'MARKDOWN'
-    TEXT = 'TEXT'
-    
-
-class Period(IntEnum):
-
-    zero = 0
-    one = 1
-    two = 2
-    
 
 class Notification(BaseModel):
 
@@ -102,12 +108,14 @@ from sqlalchemy.dialects.postgresql import JSON
 
 db = Gino()
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(db.Model):
 

--- a/tests/functional/generator/test_pydantic_models.py
+++ b/tests/functional/generator/test_pydantic_models.py
@@ -92,12 +92,14 @@ import datetime
 from typing import Optional
 from pydantic import BaseModel, Json
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(BaseModel):
 
@@ -157,12 +159,14 @@ import datetime
 from typing import Optional
 from pydantic import BaseModel, Json
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(BaseModel):
 

--- a/tests/functional/generator/test_sqlalchemy.py
+++ b/tests/functional/generator/test_sqlalchemy.py
@@ -11,12 +11,14 @@ from sqlalchemy.dialects.postgresql import JSON
 
 Base = declarative_base()
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(Base):
 
@@ -263,12 +265,14 @@ from sqlalchemy.dialects.postgresql import JSON
 
 Base = declarative_base()
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(Base):
 

--- a/tests/functional/generator/test_sqlmodel.py
+++ b/tests/functional/generator/test_sqlmodel.py
@@ -12,12 +12,14 @@ from sqlalchemy.sql import func
 from sqlalchemy.dialects.postgresql import JSON
 from pydantic import Json, UUID4
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(SQLModel, table=True):
 
@@ -262,12 +264,14 @@ from sqlalchemy.sql import func
 from sqlalchemy.dialects.postgresql import JSON
 from pydantic import Json, UUID4
 
+MaterialType = Enum(
+    value='MaterialType',
+    names=[
+        ('article', 'article'),
+        ('video', 'video')
+    ]
+)
 
-class MaterialType(str, Enum):
-
-    article = 'article'
-    video = 'video'
-    
 
 class Material(SQLModel, table=True):
 


### PR DESCRIPTION
The current class-based enum definition yields invalid Python syntax when enums include whitespace

```py
class EnumWithSpaces(str, Enum):
    another value = 'another value'
    some value = 'some value'
```

This PR changes the output of enums using the functional API that allows us to specify the member names using tuple lists or dicts. This way we can use names with spaces:

```py
EnumWithSpaces = Enum(
    value='EnumWithSpaces',
    names=[
        ('another value', 'another value'),
        ('some value', 'some value')
    ]
)
```

All tests are passing and updated to the new enum syntax.

Fixes #68